### PR TITLE
Read data-baseUrl param in links

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function commentIndicator(hash) {
 		return ' (comment)';
 	}
 
-	if (hash.startsWith('#pullrequestreview-')) {
+	if (hash.startsWith('#pullrequestreview-') || hash.startsWith('#discussion_r')) {
 		return ' (review)';
 	}
 

--- a/index.js
+++ b/index.js
@@ -239,7 +239,8 @@ function applyToLink(a, currentUrl) {
 		(a.href === a.textContent.trim() || a.href === `${a.textContent}/`)
 		&& !a.firstElementChild
 	) {
-		const shortened = shortenURL(a.href, currentUrl);
+		let url = a.dataset.baseUrl || a.href
+		const shortened = shortenURL(url, currentUrl);
 		a.innerHTML = shortened;
 		return true;
 	}

--- a/index.js
+++ b/index.js
@@ -239,7 +239,7 @@ function applyToLink(a, currentUrl) {
 		(a.href === a.textContent.trim() || a.href === `${a.textContent}/`)
 		&& !a.firstElementChild
 	) {
-		let url = a.dataset.baseUrl || a.href
+		const url = a.dataset.baseUrl || a.href;
 		const shortened = shortenURL(url, currentUrl);
 		a.innerHTML = shortened;
 		return true;

--- a/test.js
+++ b/test.js
@@ -459,6 +459,10 @@ test('GitHub.com URLs', urlMatcherMacro, new Map([
 		'#33 (review)',
 	],
 	[
+		'https://togithub.com/fregante/shorten-repo-url/pull/33#discussion_r750069394',
+		'#33 (review)',
+	],
+	[
 		'https://togithub.com/nodejs/node/pull/123',
 		'nodejs/node#123',
 	],


### PR DESCRIPTION
Now it is possible to check if the link have an attribute `dat-base-url`, if it does this is the URL to be shorted, otherwise it will make `href` shorter.

This change is necessary to fix this issue https://github.com/refined-github/refined-github/issues/5890