### PR TITLE
Improve support for certain emojis in labels

### DIFF
--- a/index.js
+++ b/index.js
@@ -244,13 +244,22 @@ function shortenRepoUrl(href, currentUrl = 'https://github.com') {
 	return pathname.replaceAll(/^[/]|[/]$/g, '') + url.search + hash + query;
 }
 
+// Without this, <a>%%</a> would throw an error
+function safeDecode(url) {
+	try {
+		return decodeURIComponent(url);
+	} catch {
+		return url;
+	}
+}
+
 export function applyToLink(a, currentUrl) {
 	// Shorten only if the link name hasn't been customized.
 	// .href automatically adds a / to naked origins so that needs to be tested too
 	// `trim` makes it compatible with this feature: https://github.com/sindresorhus/refined-github/pull/3085
-	// `decodeURIComponent` is needed because some URLs are encoded in different ways in the DOM and in the `href` property: https://github.com/refined-github/shorten-repo-url/issues/19
-	const url = decodeURIComponent(a.dataset.originalHref ?? a.href);
-	const label = decodeURIComponent(a.textContent);
+	// `safeDecode` is needed because some URLs are encoded in different ways in the DOM and in the `href` property: https://github.com/refined-github/shorten-repo-url/issues/19
+	const url = safeDecode(a.dataset.originalHref ?? a.href);
+	const label = safeDecode(a.textContent);
 	if (
 		(url === label.trim() || url === `${label}/`)
 		&& !a.firstElementChild

--- a/index.js
+++ b/index.js
@@ -248,9 +248,11 @@ export function applyToLink(a, currentUrl) {
 	// Shorten only if the link name hasn't been customized.
 	// .href automatically adds a / to naked origins so that needs to be tested too
 	// `trim` makes it compatible with this feature: https://github.com/sindresorhus/refined-github/pull/3085
-	const url = a.dataset.originalHref ?? a.href;
+	// `decodeURIComponent` is needed because some URLs are encoded in different ways in the DOM and in the `href` property: https://github.com/refined-github/shorten-repo-url/issues/19
+	const url = decodeURIComponent(a.dataset.originalHref ?? a.href);
+	const label = decodeURIComponent(a.textContent);
 	if (
-		(url === a.textContent.trim() || url === `${a.textContent}/`)
+		(url === label.trim() || url === `${label}/`)
 		&& !a.firstElementChild
 	) {
 		const shortened = shortenRepoUrl(url, currentUrl);

--- a/index.test.js
+++ b/index.test.js
@@ -207,6 +207,10 @@ test('GitHub.com URLs', urlMatcherMacro, new Map([
 		'nodejs/node/Please! ♥ (label)',
 	],
 	[
+		'https://github.com/refined-github/refined-github/labels/Please%21%20♥%EF%B8%8E',
+		'refined-github/refined-github/Please! ♥︎ (label)',
+	],
+	[
 		'https://github.com/fregante/shorten-repo-url/archive/6.4.1.zip',
 		'<code>6.4.1</code>.zip',
 	],


### PR DESCRIPTION
So it turns out this is not an issue with the shortener itself, but rather in how GitHub sets the `href` and `textContent` of the URLs.

```
href:
https://github.com/sindresorhus/refined-github/labels/Please%21%20♥%EF%B8%8E

text content:
https://github.com/sindresorhus/refined-github/labels/Please%21%20%E2%99%A5%EF%B8%8E
```

so the check in `applyToLink` does not pass (i.e. href and label don't match). This is why that link was not even being trimmed of `https://`