### PR TITLE
Add new redirect domain `redirect.github.com`

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,6 +94,7 @@ function shortenRepoUrl(href, currentUrl = 'https://github.com') {
 	const isRedirection = [
 		'https://togithub.com', // Renovate
 		'https://github-redirect.dependabot.com', // Dependabot
+		'https://redirect.github.com', // Dependabot
 	].includes(origin);
 
 	let [


### PR DESCRIPTION
Now used by Dependabot. Example: https://redirect.github.com/dependabot/dependabot-core/pull/10116