### PR TITLE
Drop support for labels

### DIFF
--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -72,7 +72,7 @@ exports[`https://github.com/fregante/shorten-repo-url/issues?q=wow 1`] = `fregan
 
 exports[`https://github.com/fregante/shorten-repo-url/labels 1`] = `fregante/shorten-repo-url/labels`;
 
-exports[`https://github.com/fregante/shorten-repo-url/labels/npm 1`] = `npm (label)`;
+exports[`https://github.com/fregante/shorten-repo-url/labels/npm 1`] = `fregante/shorten-repo-url/labels/npm`;
 
 exports[`https://github.com/fregante/shorten-repo-url/milestone/25 1`] = `fregante/shorten-repo-url/milestone/25`;
 
@@ -156,9 +156,9 @@ exports[`https://github.com/nodejs/node/graphs/commit-activity 1`] = `nodejs/nod
 
 exports[`https://github.com/nodejs/node/labels 1`] = `nodejs/node/labels`;
 
-exports[`https://github.com/nodejs/node/labels/Please%21%20♥ 1`] = `nodejs/node/Please! ♥ (label)`;
+exports[`https://github.com/nodejs/node/labels/Please%21%20♥ 1`] = `nodejs/node/labels/Please%21%20%E2%99%A5`;
 
-exports[`https://github.com/nodejs/node/labels/npm 1`] = `nodejs/node/npm (label)`;
+exports[`https://github.com/nodejs/node/labels/npm 1`] = `nodejs/node/labels/npm`;
 
 exports[`https://github.com/nodejs/node/milestone/25 1`] = `nodejs/node/milestone/25`;
 
@@ -194,7 +194,7 @@ exports[`https://github.com/pulls 1`] = `github.com/pulls`;
 
 exports[`https://github.com/pulls?q=is%3Apr++is%3Aopen+sort%3Aupdated-desc+&unrelated=true 1`] = `github.com/pulls?unrelated=true (is:open sort:updated-desc)`;
 
-exports[`https://github.com/refined-github/refined-github/labels/Please%21%20♥%EF%B8%8E 1`] = `refined-github/refined-github/Please! ♥︎ (label)`;
+exports[`https://github.com/refined-github/refined-github/labels/Please%21%20♥%EF%B8%8E 1`] = `refined-github/refined-github/labels/Please%21%20%E2%99%A5%EF%B8%8E`;
 
 exports[`https://github.com/refined-github/refined-github/wiki/%22Can-you-add-this-feature%3F%22 1`] = `Wiki: "Can you add this feature?" (refined-github/refined-github)`;
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ import reservedNames from 'github-reserved-names/reserved-names.json' with { typ
 
 const patchDiffRegex = /[.](patch|diff)$/;
 const releaseRegex = /^releases[/]tag[/]([^/]+)/;
-const labelRegex = /^labels[/]([^/]+)/;
 const compareRegex = /^compare[/]([^/]+)/;
 const pullRegex = /^pull[/](?<pull>\d+)(?:[/](?<pullPage>[^/]+))?(?:[/](?<pullPartialStart>[\da-f]{40})[.][.](?<pullPartialEnd>[\da-f]{40}))?$/;
 const issueRegex = /^issues[/](\d+)$/;
@@ -138,7 +137,6 @@ function shortenRepoUrl(href, currentUrl = 'https://github.com') {
 	const [, release] = repoPath.match(releaseRegex) || [];
 	const [, releaseTag, releaseTagExtension] = repoPath.match(releaseArchiveRegex) || [];
 	const [, downloadTag, downloadFilename] = repoPath.match(releaseDownloadRegex) || [];
-	const [, label] = repoPath.match(labelRegex) || [];
 	const [, compare] = repoPath.match(compareRegex) || [];
 	const {pull, pullPage, pullPartialStart, pullPartialEnd} = repoPath.match(pullRegex)?.groups ?? {};
 	const [, issue] = isRedirection ? repoPath.match(issueRegex) || [] : [];
@@ -220,13 +218,6 @@ function shortenRepoUrl(href, currentUrl = 'https://github.com') {
 	if (downloadFilename) {
 		const partial = joinValues([repoUrl, `<code>${downloadTag}</code>`], '@');
 		return `${partial} ${downloadFilename}${search}${hash} (download)`;
-	}
-
-	if (label) {
-		return (
-			joinValues([repoUrl, decodeURIComponent(label)])
-			+ `${search}${hash} (label)`
-		);
 	}
 
 	if (isDependents) {

--- a/index.test.js
+++ b/index.test.js
@@ -61,6 +61,8 @@ const urls = [
 	'https://github.com/nodejs/node/compare/master',
 	'https://github.com/nodejs/node/compare/master...master',
 	'https://github.com/nodejs/node/milestone/25',
+
+	// Labels are here for verification, but in GitHub has already been shortening them
 	'https://github.com/fregante/shorten-repo-url/labels/npm',
 	'https://github.com/nodejs/node/labels/npm',
 	'https://github.com/nodejs/node/labels/Please%21%20♥',


### PR DESCRIPTION
They're being rendered as https://github.com/refined-github/shorten-repo-url/labels/bug and https://github.com/refined-github/shorten-repo-url/labels/help%20wanted

