### PR TITLE
Restore support for `https://github.com` exception

### DIFF
--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -16,6 +16,8 @@ exports[`https://example.com/nodejs/node/blob/cc8fc46/.gitignore 1`] = `example.
 
 exports[`https://example.site/한글로-된-URL 1`] = `example.site/한글로-된-URL`;
 
+exports[`https://github.com 1`] = `github.com`;
+
 exports[`https://github.com/ 1`] = `github.com`;
 
 exports[`https://github.com/bfred-it/shorten-repo-url/network/dependencies 1`] = `bfred-it/shorten-repo-url (dependencies)`;

--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ function shortenRepoUrl(href, currentUrl = 'https://github.com') {
 	 * Parse URL manually to avoid URL encoding and punycode
 	 */
 	const origin = href.split('/', 3).join('/');
-	const pathname = href.slice(origin.length).replace(/[?#].*/, '');
+	const pathname = href.slice(origin.length).replace(/[?#].*/, '') || '/';
 	const hash = /#.+$/.exec(href)?.[0] ?? '';
 
 	// Use URL exclusively for search parameters because they're too hard to parse

--- a/index.test.js
+++ b/index.test.js
@@ -118,6 +118,7 @@ const urls = [
 	'https://github.com/trending/developers',
 	'https://github.com/settings/profile',
 	'https://github.com/',
+	'https://github.com',
 	'https://github.com/fregante/shorten-repo-url/issues',
 	'https://github.com/fregante/shorten-repo-url/issues?q=wow',
 	'https://github.com/fregante/shorten-repo-url/issues?q=is%3Aissue++is%3Aopen+sort%3Aupdated-desc+&unrelated=true',


### PR DESCRIPTION
Test URL:

https://github.com/download-directory/download-directory.github.io/issues/143

<img width="1875" alt="image" src="https://github.com/user-attachments/assets/d8fbcf02-b49f-40a1-a216-2f9e6f351552">
