### PR TITLE
Fix duplicated query string and hash in bare-domain links

### DIFF
--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -1,5 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`http://example.com?utm_source=newsletter 1`] = `http://example.com?utm_source=newsletter`;
+
 exports[`http://www.google.com/ 1`] = `http://www.google.com`;
 
 exports[`https://cdn.rawgit.com/fregante/shorten-repo-url/d71718db/.gitignore 1`] = `<code>d71718db</code>/.gitignore (raw)`;
@@ -12,7 +14,13 @@ exports[`https://cdn.rawgit.com/nodejs/node/v0.12/.gitignore 1`] = `nodejs/node@
 
 exports[`https://developer.mozilla.org/en-US/docs/Web/API/Document/createElement#parameters 1`] = `developer.mozilla.org/en-US/docs/Web/API/Document/createElement#parameters`;
 
+exports[`https://example.com#section 1`] = `example.com#section`;
+
+exports[`https://example.com/?id=42 1`] = `example.com?id=42`;
+
 exports[`https://example.com/nodejs/node/blob/cc8fc46/.gitignore 1`] = `example.com/nodejs/node/blob/cc8fc46/.gitignore`;
+
+exports[`https://example.com?utm_source=newsletter 1`] = `example.com?utm_source=newsletter`;
 
 exports[`https://example.site/한글로-된-URL 1`] = `example.site/한글로-된-URL`;
 
@@ -261,6 +269,8 @@ exports[`https://togithub.com/nodejs/node/pull/123/files 1`] = `nodejs/node#123 
 exports[`https://togithub.com/refined-github/refined-github/commit/4f270c4f50e0a2a20085a6e92095117f10340322 1`] = `refined-github/refined-github@<code>4f270c4</code>`;
 
 exports[`https://togithub.com/refined-github/refined-github/commit/e81a9646b448d90c7e02ab41332cab0507dccbbd#commitcomment-60089354 1`] = `refined-github/refined-github@<code>e81a964</code> (comment)`;
+
+exports[`https://www.example.com?id=42 1`] = `example.com?id=42`;
 
 exports[`https://www.google.com/ 1`] = `google.com`;
 

--- a/fixtures/urls.js
+++ b/fixtures/urls.js
@@ -135,4 +135,11 @@ export const urls = [
 	'https://example.com/nodejs/node/blob/cc8fc46/.gitignore',
 	'https://example.site/한글로-된-URL',
 	'https://한글로-된-경로.com/하위경로#한글-해시',
+
+	// Bare domain with a query/hash immediately after the host (no path) #regression
+	'https://example.com?utm_source=newsletter',
+	'http://example.com?utm_source=newsletter',
+	'https://example.com#section',
+	'https://www.example.com?id=42',
+	'https://example.com/?id=42',
 ];

--- a/index.js
+++ b/index.js
@@ -86,7 +86,9 @@ function shortenRepoUrl(href, currentUrl = 'https://github.com') {
 	/**
 	 * Parse URL manually to avoid URL encoding and punycode
 	 */
-	const origin = href.split('/', 3).join('/');
+	// Strip any `?query`/`#hash` that follows the host directly (no path), otherwise
+	// it gets absorbed into `origin` and later re-appended → duplicated query/hash
+	const origin = href.split('/', 3).join('/').replace(/[?#].*/, '');
 	const pathname = href.slice(origin.length).replace(/[?#].*/, '') || '/';
 	const hash = /#.+$/.exec(href)?.[0] ?? '';
 


### PR DESCRIPTION
### The bug

When a URL's host is followed **directly** by `?` or `#` with no path, the shortened text repeats the query string / hash:

| Input | Shortened (before) | Expected |
| --- | --- | --- |
| `https://example.com?foo=bar` | `example.com?foo=bar?foo=bar` | `example.com?foo=bar` |
| `https://example.com#frag` | `example.com#frag#frag` | `example.com#frag` |

This is visible in the wild via Refined GitHub's `shorten-links` feature: a comment containing a bare-domain link with a query string (e.g. a CI preview-environment link like `https://sub.example.com?preview_id=123`) renders its link **text** with the query string twice, while the `href` stays correct.

### Root cause

`origin` is parsed manually to avoid encoding/punycode issues:

```js
const origin = href.split('/', 3).join('/');
```

This assumes a `scheme://host/…` shape. When there is no `/` between the host and the `?`/`#`, the query/hash is absorbed **into `origin`**. The bare-domain branch (`pathname === '/'`) then appends `url.search` / `decodeURI(url.hash)` a second time, producing the duplication.

A trailing slash (`example.com/?foo=bar`) makes `split('/', 3)` stop at the host, so the bug only triggers on the slash-less form — which is why no existing fixture caught it.

### The fix

Strip any `?query`/`#hash` from `origin` so it stays `scheme://host[:port]`:

```diff
-const origin = href.split('/', 3).join('/');
+const origin = href.split('/', 3).join('/').replace(/[?#].*/, '');
```

The `replace` is a no-op for any URL that has a path (i.e. every previously-handled case), so **all existing snapshots are unchanged** — the snapshot diff is purely additive.

### Tests

Added bare-domain regression fixtures covering query + hash, across `https` (scheme stripped), `http` (scheme retained), `www`, and the already-working trailing-slash variant. `npm test` (xo + tsd + vitest, 141 tests) passes.